### PR TITLE
Use environment variable for secret key

### DIFF
--- a/webserver/outcropsketch/settings.py
+++ b/webserver/outcropsketch/settings.py
@@ -25,12 +25,12 @@ load_dotenv(PROJECT_ROOT / '.env')
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-p$lhrjw^4dfp+%s$$^f^rj*#m!08)568=nh3zt2d4or8ln0u1f'
+SECRET_KEY = os.environ(DJANGO_SECRET_KEY, 'django-insecure-p$lhrjw^4dfp+%s$$^f^rj*#m!08)568=nh3zt2d4or8ln0u1f')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['.outcropsketch.com', '127.0.0.1']
 
 # Application definition
 


### PR DESCRIPTION
No longer uses a hardcoded value for the Django secret key now that the repo is public