### PR TITLE
Same-label merging bugfix

### DIFF
--- a/src/utils/paperLayers.ts
+++ b/src/utils/paperLayers.ts
@@ -155,7 +155,7 @@ export function handleOverlap(insertedItem: paper.PathItem, layer: Layer): paper
   });
 
   let invalid = false;
-  [...differentLabel, ...sameLabel].forEach((item: paper.PathItem) => {
+  [...sameLabel, ...differentLabel].forEach((item: paper.PathItem) => {
     // Do nothing for the path being drawn and non-intersecting items
     if (item === insertedItem || invalid) return;
 

--- a/src/utils/projectToMask.ts
+++ b/src/utils/projectToMask.ts
@@ -120,6 +120,7 @@ export default function projectToMask(): number[][][] {
         const hit = paper.project.layers[layer].hitTest(projectCoordinate, hitTestOptions);
         if (hit) {
           const label = hit.item.data.label;
+          // TODO: this will throw an error if non-default labels are used, should instead warn the user the label type isn't supported
           const labelValue = labelValues[label];
           console.assert(labelValue !== undefined, `Invalid label ${label} on item ${hit.item}`);
           mask[y][x][c] = labelValue;


### PR DESCRIPTION
Makes it so inserted labels will merge with labels of the same type before different ones, making behavior more consistent when drawing labels while toggling merging on and off